### PR TITLE
Reintroduce Freetype, JPEG and XPM support in GD

### DIFF
--- a/php74.spec
+++ b/php74.spec
@@ -57,7 +57,7 @@
 Summary: PHP scripting language for creating dynamic web sites
 Name: php74
 Version: 7.4.6
-Release: 1%{?dist}
+Release: 2%{?dist}
 # All files licensed under PHP version 3.01, except
 # Zend is licensed under Zend
 # TSRM is licensed under BSD
@@ -1045,7 +1045,10 @@ build --libdir=%{_libdir}/php \
 %if %{with_libgd}
       --with-external-gd \
 %else
+      --with-freetype \
       --with-webp \
+      --with-jpeg \
+      --with-xpm \
 %endif
       --with-gmp=shared \
       --enable-calendar=shared \
@@ -1177,7 +1180,10 @@ build --includedir=%{_includedir}/php-zts \
 %if %{with_libgd}
       --with-external-gd \
 %else
+      --with-freetype \
       --with-webp \
+      --with-jpeg \
+      --with-xpm \
 %endif
       --with-gmp=shared \
       --enable-calendar=shared \
@@ -1687,6 +1693,9 @@ exit 0
 
 
 %changelog
+* Mon May 18 2020 David Alger <davidmalger@gmail.com> - 7.4.6-2
+- Reintroduce freetype, jpeg and xpm support in GD
+
 * Mon May 18 2020 David Alger <davidmalger@gmail.com> - 7.4.6-1
 - Latest upstream
 


### PR DESCRIPTION
php73 and prior [configured the bundled GD](https://github.com/iusrepo/php73/blob/master/php73.spec#L1031-L1035) to include Freetype, JPEG and XPM support. This PR updates the php74.spec to similarly specify the appropriate options for continued compatibility with software which relies on them. I discovered this delta when Magento, which I've been running on IUS for years, complained about `imagecreatefromjpeg` missing and then set out to resolve the issue by patching my local build of php74 packages to test it.

**`php -i` output from php73 packages:**
```
GD Support => enabled
GD Version => bundled (2.1.0 compatible)
FreeType Support => enabled
FreeType Linkage => with freetype
FreeType Version => 2.8.0
GIF Read Support => enabled
GIF Create Support => enabled
JPEG Support => enabled
libJPEG Version => 6b
PNG Support => enabled
libPNG Version => 1.5.13
WBMP Support => enabled
XPM Support => enabled
libXpm Version => 30411
XBM Support => enabled
WebP Support => enabled
```

**`php -i` output from php74 packages; built WITHOUT these changes:**
```
GD Support => enabled
GD Version => bundled (2.1.0 compatible)
GIF Read Support => enabled
GIF Create Support => enabled
PNG Support => enabled
libPNG Version => 1.5.13
WBMP Support => enabled
XBM Support => enabled
WebP Support => enabled
BMP Support => enabled
TGA Read Support => enabled
```

**`php -i` output from php74 packages; built WITH these changes:**
```
GD Support => enabled
GD Version => bundled (2.1.0 compatible)
FreeType Support => enabled
FreeType Linkage => with freetype
FreeType Version => 2.8.0
GIF Read Support => enabled
GIF Create Support => enabled
JPEG Support => enabled
libJPEG Version => 6b
PNG Support => enabled
libPNG Version => 1.5.13
WBMP Support => enabled
XPM Support => enabled
libXpm Version => 30411
XBM Support => enabled
WebP Support => enabled
BMP Support => enabled
TGA Read Support => enabled
```